### PR TITLE
chore: updated setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'pytest>=6.2.5',
     ],
     zip_safe=False,  # Required for full installation.
-    python_requires='>=3.7',
+    python_requires='>=3.9,<3.11',
     classifiers=[
         # TODO(b/241264065): list classifiers.
         'Topic :: Scientific/Engineering :: Artificial Intelligence',


### PR DESCRIPTION
I updated setup.py to reflect working python versions.

While using versions below Python 3.9, you receive this stack trace from [here](https://github.com/deepmind/csuite/blob/bec2c69fa5f56dd0e5903d8a2a5736091b8d6c1c/csuite/environments/access_control.py#L65):
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/michaelogezi/miniconda3/envs/csuite/lib/python3.8/site-packages/csuite/__init__.py", line 21, in <module>
    from csuite.environments import access_control
  File "/Users/michaelogezi/miniconda3/envs/csuite/lib/python3.8/site-packages/csuite/environments/access_control.py", line 52, in <module>
    class Params:
  File "/Users/michaelogezi/miniconda3/envs/csuite/lib/python3.8/site-packages/csuite/environments/access_control.py", line 65, in Params
    priorities: list[float]
TypeError: 'type' object is not subscriptable
```

Python <3.9 doesn't support lower-case type hints such as `list[float]`. It instead expects us to import `List` from `typing` and use `List[float]`.