### PR TITLE
fixed small bug in rendering code

### DIFF
--- a/csuite/environments/access_control.py
+++ b/csuite/environments/access_control.py
@@ -234,7 +234,7 @@ class AccessControl(base.Environment):
     return copy.deepcopy(self._params)
 
   def render(self):
-    board = np.ones((len(_PRIORITIES), _NUM_SERVERS), dtype=np.uint8)
+    board = np.ones((len(_PRIORITIES), _NUM_SERVERS + 1), dtype=np.uint8)
     priority = _PRIORITIES.index(self._state.incoming_priority)
     busy_num = self._state.num_busy_servers
     board[priority, busy_num] = 0


### PR DESCRIPTION
There are `num_priorities * (num_servers + 1)` states in accesscontrol (because there can be 0–`num_servers` free servers), so the 'board' should have that many positions as well. Otherwise `render()` fails at the first timestep when there are 10 free servers but the board size is [4,10] instead of [4,11].